### PR TITLE
improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ locals {
 module "cloudinit" {
   source  = "tedivm/cloudinit/general"
   version = "~> 1.0
+  
+  package_update = true
 
   packages = ["unzip", "jq"]
 

--- a/main.tf
+++ b/main.tf
@@ -41,6 +41,9 @@ locals {
       "bootcmd" : var.bootcmd,
       "mounts" : var.mounts,
       "packages" : var.packages,
+      "package_update": var.package_update,
+      "package_upgrade": var.package_upgrade,
+      "package_reboot_if_required": var.package_reboot_if_required,
       "growpart" : {
         "mode" : "auto",
         "devices" : concat(["/"], var.grow_partition_devices)
@@ -67,10 +70,10 @@ data "cloudinit_config" "main" {
   dynamic "part" {
     for_each = var.parts
     content {
-      content      = parts.value["content"]
-      filename     = try(parts.value["filename"], null)
-      content_type = try(parts.value["content_type"], null)
-      merge_type   = try(parts.value["merge_type"], null)
+      content      = part.value["content"]
+      filename     = try(part.value["filename"], null)
+      content_type = try(part.value["content_type"], null)
+      merge_type   = try(part.value["merge_type"], null)
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -74,3 +74,4 @@ data "cloudinit_config" "main" {
     }
   }
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -41,7 +41,7 @@ variable "user_services" {
 variable "packages" {
   description = "A list of packages to be installed. These packages must exist in the systems software repository, or have a repository configured."
   type        = list(string)
-  default     = ["nomad", "consul", "docker-ce", "docker-ce-cli", "containerd.io"]
+  default     = []
 }
 
 variable "package_update" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,9 +1,3 @@
-
-terraform {
-  experiments = [module_variable_optional_attrs]
-}
-
-
 #
 # Commands
 #
@@ -102,3 +96,4 @@ variable "parts" {
     }
   ))
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -44,6 +44,24 @@ variable "packages" {
   default     = ["nomad", "consul", "docker-ce", "docker-ce-cli", "containerd.io"]
 }
 
+variable "package_update" {
+  description = "Update apt database on first boot (run 'apt-get update'). Happens before upgrade or a package install."
+  type = bool
+  default = false
+}
+
+variable "package_upgrade" {
+  description = "Upgrade packages. Happens before a package install."
+  type = bool
+  default = false
+}
+
+variable "package_reboot_if_required" {
+  description = "Reboot the system if required by presence of /var/run/reboot-required"
+  type = bool
+  default = false
+}
+
 
 #
 # Files


### PR DESCRIPTION
new features:
- support for `package_update`, `package_upgrade`, `package_reboot_if_required`

fixes:
- `dynamic "part"` was broken due to wrong iteration temp variable

miscellaneous:
- removed `experiments = [module_variable_optional_attrs]` since
  - a) it's already a part of new terraform 
  - b) it breaks new terraform, throws an exception that `module_variable_optional_attrs` no more allowed
  - c) according to terraform style guide it should be defined outside of a module (root module)
- packages default now empty list[], since it brings a lot of confusion when `packages` is not defined 